### PR TITLE
Convert lubelogger API calls to "culture-invariant"

### DIFF
--- a/src/lubelogger.py
+++ b/src/lubelogger.py
@@ -49,19 +49,21 @@ class Lubelogger:
             int(fillup["odometer"]),
             fillup["fuelConsumed"],
             fillup["cost"],
-            fillup["isFillToFull"] == "True",
-            fillup["missedFuelUp"] == "True",
+            fillup["isFillToFull"],
+            fillup["missedFuelUp"],
             fillup["notes"] if fillup["notes"] else "",
         )
 
     def get_fillups(self, vehicle_id: int) -> list[LubeloggerFillup]:
         """Get all fuel fillup logs from Lubelogger"""
         params = {"vehicleId": vehicle_id}
+        headers = {'culture-invariant': "true"}
         try:
             response = self.session.get(
                 f"{self.url}/api/vehicle/gasrecords",
                 params=params,
                 timeout=10,
+                headers=headers,
             )
         except requests.exceptions.ReadTimeout:
             logger.error("Lubelogger API timed out")
@@ -82,12 +84,14 @@ class Lubelogger:
     def add_fillup(self, vehicle_id: int, fillup: LubeloggerFillup):
         """Add a fuel fillup log to Lubelogger"""
         params = {"vehicleId": vehicle_id}
+        headers = {'culture-invariant': "true"}
         try:
             response = self.session.post(
                 f"{self.url}/api/vehicle/gasrecords/add",
                 fillup.to_lubelogger_api_format(),
                 params=params,
                 timeout=10,
+                headers=headers,
             )
         except requests.exceptions.ReadTimeout:
             logger.error("Lubelogger API timed out")
@@ -101,10 +105,12 @@ class Lubelogger:
 
     def get_vehicle_info(self, vehicle_id: int) -> dict:
         """Get vehicle info from Lubelogger"""
+        headers = {'culture-invariant': "true"}
         try:
             response = self.session.get(
                 f"{self.url}/api/vehicles",
                 timeout=10,
+                headers=headers,
             )
         except requests.exceptions.ReadTimeout:
             logger.error("Lubelogger API timed out")

--- a/src/main.py
+++ b/src/main.py
@@ -114,10 +114,10 @@ def lubelogger_converter(fillup) -> LubeloggerFillup:
         fillup_notes += f"\n\n###### Fuelio notes:\n\n{fillup[None][8]}"
 
     return LubeloggerFillup(
-        date            = fillup_datetime.strftime('%d/%m/%Y'),
+        date            = fillup_datetime.strftime('%Y-%m-%d'),
         odometer        = int(float(fillup[None][0])),
-        fuel_consumed   = fillup[None][1],
-        cost            = fillup[None][3],
+        fuel_consumed   = float(fillup[None][1]),
+        cost            = float(fillup[None][3]),
         is_fill_to_full = int(fillup[None][2]) == 1,
         missed_fuel_up  = int(fillup[None][9]) == 1,
         notes           = fillup_notes
@@ -197,8 +197,8 @@ def process_fillups(
                 # Log each key/value pair that does not match
                 for k, v in new_ll_fill.to_dict().items():
                     if k in dupe_ll_fill and v != dupe_ll_fill[k]:
-                        logger.warning('The current value of attribute "%s":\n%s', k, dupe_ll_fill[k])
-                        logger.warning('The incoming value of attribute "%s":\n%s', k, v)
+                        logger.warning('The current value of attribute "%s":\n%s', k, repr(dupe_ll_fill[k]))
+                        logger.warning('The incoming value of attribute "%s":\n%s', k, repr(v))
 
                 # Skip this fillup
                 continue


### PR DESCRIPTION
By default, LubeLogger uses locale-specific data formats in API calls By adding the "culture-invariant" header to the API calls, this behaviour is changed to use locale-independant formats, allowing the use of date formats in LubeLogger other than dd/mm/yyyy

Also updated logging output for non-matching entries to use python repr output in order to distinguish when there is a type mismatch rather than a value mismatch (1.23 vs '1.23') which wasn't visible previously.

Addresses issue #6 